### PR TITLE
change class name in home page

### DIFF
--- a/src/main/java/com/arcbees/website/client/application/home/HomeView.ui.xml
+++ b/src/main/java/com/arcbees/website/client/application/home/HomeView.ui.xml
@@ -129,14 +129,12 @@
                     </a>
                 </div>
             </div>
-            <div class="{res.style.wrapper} {res.style.centered} {page.style.successStoryMore}"
-                    ui:field="successStoryMore">
-                <div class="{res.grid.row} {res.style.clearfix}">
-                    <div class="{res.grid.col} {res.grid.col_full} {res.style.centered} {page.style.ssicons}">
-                        <g:Image styleName="{res.style.mobileHidden}" resource="{page.ssicons}"/>
-                        <g:Image styleName="{res.style.mobileVisible}" resource="{page.ssiconsMobile}"/>
-                        <div class="{page.style.ssiconsHexa}">
-                            <svg version="1.1" id="Layer_1" x="0px" y="0px"
+            <div class="{res.style.wrapper} {res.style.centered} {page.style.successStoryMore}" ui:field="successStoryMore">
+                <div class="{res.style.centered} {page.style.successStorylogos}">
+                    <g:Image styleName="{res.style.mobileHidden}" resource="{page.ssicons}"/>
+                    <g:Image styleName="{res.style.mobileVisible}" resource="{page.ssiconsMobile}"/>
+                    <div class="{page.style.successStoryHexa}">
+                        <svg version="1.1" id="Layer_1" x="0px" y="0px"
                              width="495.746px" height="163.688px" viewBox="0 0 495.746 163.688" enable-background="new 0 0 495.746 163.688"
                              xml:space="preserve">
                             <path class="{page.style.path1}" fill="none" stroke="#fff" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
@@ -152,8 +150,9 @@
                                 c0.431,0,0.827-0.23,1.041-0.604l44.226-77.143c0.21-0.37,0.21-0.825,0-1.194L447.863,4.103c-0.214-0.374-0.61-0.603-1.041-0.603
                                 h-88.481c-0.43,0-0.828,0.23-1.042,0.603l-25.978,45.773"/>
                         </svg>
-                        </div>
                     </div>
+                </div>
+                <div class="{res.grid.row} {res.style.clearfix}">
                     <div class="{res.grid.col} {res.grid.col_1_3} {res.grid.col_m_full}">
                         <h3>
                             <ui:msg description="Home - The Genesis Of GWTP - title">The Genesis

--- a/src/main/java/com/arcbees/website/client/resources/PageHomeResources.java
+++ b/src/main/java/com/arcbees/website/client/resources/PageHomeResources.java
@@ -53,15 +53,11 @@ public interface PageHomeResources extends FontResources {
 
         String collapsible();
 
-        String ssicons();
-
         String successStoryHolder();
 
         String path3();
 
         String path2();
-
-        String ssiconsHexa();
 
         String logoConstruct();
 
@@ -82,6 +78,10 @@ public interface PageHomeResources extends FontResources {
         String btns();
 
         String beeTheBest();
+
+        String successStorylogos();
+
+        String successStoryHexa();
     }
 
     @Source("img/pages/homeBeesBg.png")

--- a/src/main/resources/com/arcbees/website/client/resources/css/pages/home.gss
+++ b/src/main/resources/com/arcbees/website/client/resources/css/pages/home.gss
@@ -343,25 +343,23 @@
     margin-top: 1em;
 }
 
-.home .ssicons {
+.home .successStorylogos {
     margin: 0 0 4em 0em;
+
+    position: relative;
 }
 
-.home .ssicons img {
-    margin-left: -1.5rem;
-}
-
-.home .ssiconsHexa {
+.home .successStoryHexa {
     margin-left: -24.8rem;
     width: 49.7rem;
 
     position: absolute;
-    top: -1.6rem;
+    top: 0;
     left: 50%;
 }
 
 @if (is("ie8") || is("ie9")) {
-    .home .ssiconsHexa {
+    .home .successStoryHexa {
         display: none;
     }
 }
@@ -371,11 +369,7 @@
         font-size: 1.8rem;
     }
 
-    .home .ssicons img {
-        margin-left: 0;
-    }
-
-    .home .ssiconsHexa {
+    .home .successStoryHexa {
         margin-left: -50%;
         width: 100%;
         top: 0;
@@ -383,7 +377,7 @@
 }
 
 @media (max-width: 649px) {
-    .home .ssiconsHexa {
+    .home .successStoryHexa {
         display: none;
     }
 
@@ -398,15 +392,11 @@
     .home .successStoryMore {
         background: none;
     }
-
-    .home .ssicons img {
-        margin-left: 0;
-    }
 }
 
-.home .ssiconsHexa .path1,
-.home .ssiconsHexa .path2,
-.home .ssiconsHexa .path3 {
+.home .successStoryHexa .path1,
+.home .successStoryHexa .path2,
+.home .successStoryHexa .path3 {
     stroke-dasharray: 1500;
     stroke-dashoffset: 1500;
     -webkit-animation: path 1.5s linear;
@@ -419,15 +409,15 @@
     animation-fill-mode: forwards;
 }
 
-.home .ssiconsHexa .path1 {
+.home .successStoryHexa .path1 {
     @mixin animation_delay(1s);
 }
 
-.home .ssiconsHexa .path2 {
+.home .successStoryHexa .path2 {
     @mixin animation_delay(1.5s);
 }
 
-.home .ssiconsHexa .path3 {
+.home .successStoryHexa .path3 {
     @mixin animation_delay(2s);
 }
 


### PR DESCRIPTION
I changed some classes name because they contained the word "icon" and it was creating a little visual conflict with the `[class*="icon"]:before` found in the icons.gss
